### PR TITLE
Add support for nested byte vectors

### DIFF
--- a/serde-generate/runtime/csharp/Serde/BinaryDeserializer.cs
+++ b/serde-generate/runtime/csharp/Serde/BinaryDeserializer.cs
@@ -65,6 +65,22 @@ namespace Serde
             return utf8.GetString(content);
         }
 
+        public ValueArray<ValueArray<byte>> deserialize_vec_bytes() {
+            long len = deserialize_len();
+            ValueArray<byte>[] content = new ValueArray<byte>[len];
+
+            if (len < 0 || len > int.MaxValue)
+            {
+                throw new DeserializationException("Incorrect length value for C# array");
+            }
+
+            for (long i = 0; i < len; i++) {
+                content[i] = deserialize_bytes();
+            }
+
+            return new ValueArray<ValueArray<byte>>(content);
+        }
+
         public ValueArray<byte> deserialize_bytes()
         {
             long len = deserialize_len();

--- a/serde-generate/runtime/csharp/Serde/BinarySerializer.cs
+++ b/serde-generate/runtime/csharp/Serde/BinarySerializer.cs
@@ -64,6 +64,13 @@ namespace Serde
 
         public void serialize_str(string value) => serialize_bytes(new ValueArray<byte>(utf8.GetBytes(value)));
 
+        public void serialize_vec_bytes(ValueArray<ValueArray<byte>> value) {
+            serialize_len(value.Count);
+            foreach (ValueArray<byte> v in value) {
+                serialize_bytes(v);
+            }
+        }
+
         public void serialize_bytes(ValueArray<byte> value)
         {
             serialize_len(value.Count);

--- a/serde-generate/runtime/csharp/Serde/IDeserializer.cs
+++ b/serde-generate/runtime/csharp/Serde/IDeserializer.cs
@@ -9,6 +9,8 @@ namespace Serde
     {
         string deserialize_str();
 
+        ValueArray<ValueArray<byte>> deserialize_vec_bytes();
+
         ValueArray<byte> deserialize_bytes();
 
         bool deserialize_bool();

--- a/serde-generate/runtime/csharp/Serde/ISerializer.cs
+++ b/serde-generate/runtime/csharp/Serde/ISerializer.cs
@@ -9,6 +9,8 @@ namespace Serde
     {
         void serialize_str(string value);
 
+        void serialize_vec_bytes(ValueArray<ValueArray<byte>> value);
+
         void serialize_bytes(ValueArray<byte> value);
 
         void serialize_bool(bool value);

--- a/serde-generate/runtime/golang/bcs/bcs_test.go
+++ b/serde-generate/runtime/golang/bcs/bcs_test.go
@@ -50,6 +50,47 @@ func TestSerializeDeserializeBytes(t *testing.T) {
 	})
 }
 
+func TestSerializeDeserializeVecBytes(t *testing.T) {
+	cases := []struct {
+		target   [][]byte
+		expected []byte
+	}{
+		{
+			target:   [][]byte{{1, 2, 38}, {0, 1}, {0}},
+			expected: []byte{3, 3, 1, 2, 38, 2, 0, 1, 1, 0},
+		},
+		{
+			target:   [][]byte{{1, 2, 38}, {0, 1}, {}},
+			expected: []byte{3, 3, 1, 2, 38, 2, 0, 1, 0},
+		},
+		{
+			target:   [][]byte{},
+			expected: []byte{0},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
+			s := bcs.NewSerializer()
+			d := bcs.NewDeserializer(tc.expected)
+
+			err := s.SerializeVecBytes(tc.target)
+			require.NoError(t, err)
+
+			deserialized, err := d.DeserializeVecBytes()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, s.GetBytes())
+			assert.Equal(t, tc.target, deserialized)
+		})
+	}
+	t.Run("deserialize error: EOF", func(t *testing.T) {
+		d := bcs.NewDeserializer([]byte{})
+		_, err := d.DeserializeVecBytes()
+		require.EqualError(t, err, "EOF")
+	})
+}
+
 func TestSerializeDeserializeStr(t *testing.T) {
 	cases := []struct {
 		target   string

--- a/serde-generate/runtime/golang/bcs/deserializer.go
+++ b/serde-generate/runtime/golang/bcs/deserializer.go
@@ -37,6 +37,10 @@ func (d *deserializer) DeserializeF64() (float64, error) {
 	return 0, errors.New("unimplemented")
 }
 
+func (d *deserializer) DeserializeVecBytes() ([][]byte, error) {
+	return d.BinaryDeserializer.DeserializeVecBytes(d.DeserializeLen)
+}
+
 func (d *deserializer) DeserializeBytes() ([]byte, error) {
 	return d.BinaryDeserializer.DeserializeBytes(d.DeserializeLen)
 }

--- a/serde-generate/runtime/golang/bcs/serializer.go
+++ b/serde-generate/runtime/golang/bcs/serializer.go
@@ -34,6 +34,10 @@ func (s *serializer) SerializeStr(value string) error {
 	return s.BinarySerializer.SerializeStr(value, s.SerializeLen)
 }
 
+func (s *serializer) SerializeVecBytes(value [][]byte) error {
+	return s.BinarySerializer.SerializeVecBytes(value, s.SerializeLen)
+}
+
 func (s *serializer) SerializeBytes(value []byte) error {
 	return s.BinarySerializer.SerializeBytes(value, s.SerializeLen)
 }

--- a/serde-generate/runtime/golang/bincode/deserializer.go
+++ b/serde-generate/runtime/golang/bincode/deserializer.go
@@ -32,6 +32,10 @@ func (d *deserializer) DeserializeF64() (float64, error) {
 	return math.Float64frombits(ret), err
 }
 
+func (d *deserializer) DeserializeVecBytes() ([][]byte, error) {
+	return d.BinaryDeserializer.DeserializeVecBytes(d.DeserializeLen)
+}
+
 func (d *deserializer) DeserializeBytes() ([]byte, error) {
 	return d.BinaryDeserializer.DeserializeBytes(d.DeserializeLen)
 }

--- a/serde-generate/runtime/golang/bincode/serializer.go
+++ b/serde-generate/runtime/golang/bincode/serializer.go
@@ -30,6 +30,10 @@ func (s *serializer) SerializeStr(value string) error {
 	return s.BinarySerializer.SerializeStr(value, s.SerializeLen)
 }
 
+func (s *serializer) SerializeVecBytes(value [][]byte) error {
+	return s.BinarySerializer.SerializeVecBytes(value, s.SerializeLen)
+}
+
 func (s *serializer) SerializeBytes(value []byte) error {
 	return s.BinarySerializer.SerializeBytes(value, s.SerializeLen)
 }

--- a/serde-generate/runtime/golang/serde/binary_deserializer.go
+++ b/serde-generate/runtime/golang/serde/binary_deserializer.go
@@ -38,6 +38,23 @@ func (d *BinaryDeserializer) DecreaseContainerDepth() {
 	d.containerDepthBudget += 1
 }
 
+func (d *BinaryDeserializer) DeserializeVecBytes(deserializeLen func() (uint64, error)) ([][]byte, error) {
+	len, err := deserializeLen()
+	if err != nil {
+		return nil, err
+	}
+	ret := make([][]byte, len)
+	for i := 0; uint64(i) < len; i++ {
+		bytes, err := d.DeserializeBytes(deserializeLen)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = bytes
+	}
+
+	return ret, err
+}
+
 // `deserializeLen` to be provided by the extending struct.
 func (d *BinaryDeserializer) DeserializeBytes(deserializeLen func() (uint64, error)) ([]byte, error) {
 	len, err := deserializeLen()

--- a/serde-generate/runtime/golang/serde/binary_serializer.go
+++ b/serde-generate/runtime/golang/serde/binary_serializer.go
@@ -33,6 +33,14 @@ func (d *BinarySerializer) DecreaseContainerDepth() {
 	d.containerDepthBudget += 1
 }
 
+func (s *BinarySerializer) SerializeVecBytes(value [][]byte, serializeLen func(uint64) error) error {
+	serializeLen(uint64(len(value)))
+	for _, bytes := range value {
+		s.SerializeBytes(bytes, serializeLen)
+	}
+	return nil
+}
+
 // `serializeLen` to be provided by the extending struct.
 func (s *BinarySerializer) SerializeBytes(value []byte, serializeLen func(uint64) error) error {
 	serializeLen(uint64(len(value)))

--- a/serde-generate/runtime/golang/serde/interfaces.go
+++ b/serde-generate/runtime/golang/serde/interfaces.go
@@ -6,6 +6,8 @@ package serde
 type Serializer interface {
 	SerializeStr(value string) error
 
+	SerializeVecBytes(value [][]byte) error
+
 	SerializeBytes(value []byte) error
 
 	SerializeBool(value bool) error
@@ -57,6 +59,8 @@ type Serializer interface {
 
 type Deserializer interface {
 	DeserializeStr() (string, error)
+
+	DeserializeVecBytes() ([][]byte, error)
 
 	DeserializeBytes() ([]byte, error)
 

--- a/serde-generate/runtime/java/com/novi/serde/BinaryDeserializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/BinaryDeserializer.java
@@ -9,6 +9,8 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.CharacterCodingException;
 import java.math.BigInteger;
+import java.util.List;
+import java.util.ArrayList;
 
 public abstract class BinaryDeserializer implements Deserializer {
     protected ByteBuffer input;
@@ -45,6 +47,19 @@ public abstract class BinaryDeserializer implements Deserializer {
             throw new DeserializationError("Incorrect UTF8 string");
         }
         return new String(content);
+    }
+
+    public List<Bytes> deserialize_vec_bytes() throws DeserializationError {
+        long len = deserialize_len();
+        if (len < 0 || len > Integer.MAX_VALUE) {
+            throw new DeserializationError("Incorrect length value for Java array");
+        }
+        List<Bytes> content = new ArrayList<Bytes>();
+        for (int i = 0; i < len; i++) {
+            content.add(deserialize_bytes());
+        }
+
+        return content;
     }
 
     public Bytes deserialize_bytes() throws DeserializationError {

--- a/serde-generate/runtime/java/com/novi/serde/BinarySerializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/BinarySerializer.java
@@ -4,6 +4,7 @@
 package com.novi.serde;
 
 import java.math.BigInteger;
+import java.util.List;
 
 public abstract class BinarySerializer implements Serializer {
     protected MyByteArrayOutputStream output;
@@ -27,6 +28,13 @@ public abstract class BinarySerializer implements Serializer {
 
     public void serialize_str(String value) throws SerializationError {
         serialize_bytes(new Bytes(value.getBytes()));
+    }
+
+    public void serialize_vec_bytes(List<Bytes> value) throws SerializationError {
+        serialize_len(value.size());
+        for (Bytes bytes : value) {
+            serialize_bytes(bytes);
+        }
     }
 
     public void serialize_bytes(Bytes value) throws SerializationError {

--- a/serde-generate/runtime/java/com/novi/serde/Deserializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/Deserializer.java
@@ -4,9 +4,12 @@
 package com.novi.serde;
 
 import java.math.BigInteger;
+import java.util.List;
 
 public interface Deserializer {
     String deserialize_str() throws DeserializationError;
+
+    List<Bytes> deserialize_vec_bytes() throws DeserializationError;
 
     Bytes deserialize_bytes() throws DeserializationError;
 

--- a/serde-generate/runtime/java/com/novi/serde/Serializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/Serializer.java
@@ -4,9 +4,12 @@
 package com.novi.serde;
 
 import java.math.BigInteger;
+import java.util.List;
 
 public interface Serializer {
     void serialize_str(String value) throws SerializationError;
+
+    void serialize_vec_bytes(List<Bytes> value) throws SerializationError;
 
     void serialize_bytes(Bytes value) throws SerializationError;
 

--- a/serde-generate/runtime/python/bcs/test_bcs.py
+++ b/serde-generate/runtime/python/bcs/test_bcs.py
@@ -138,6 +138,28 @@ class BcsTestCase(unittest.TestCase):
 
         self.assertEqual(bcs.deserialize(b"\x00", bytes), (b"", b""))
 
+    def test_serialize_vec_bytes(self):
+        a = []
+        b = [b"\x00\x00", b"\x01\x01"]
+        c = [b"\x00" * 128, b"\x01" * 127, b"\x02" * 3, b""]
+
+        aser = bcs.serialize(a, typing.Sequence[bytes])
+        bser = bcs.serialize(b, typing.Sequence[bytes])
+        cser = bcs.serialize(c, typing.Sequence[bytes])
+
+        self.assertEqual(aser, b"\x00")
+        self.assertEqual(bser, b"\x02\x02\x00\x00\x02\x01\x01")
+        self.assertEqual(cser,
+                b"\x04\x80\x01" + b"\x00" * 128 +
+                b"\x7F" + b"\x01" * 127 +
+                b"\x03" + b"\x02" * 3 +
+                b"\x00"
+        )
+
+        self.assertEqual(bcs.deserialize(aser, typing.Sequence[bytes]), (a, b""))
+        self.assertEqual(bcs.deserialize(bser, typing.Sequence[bytes]), (b, b""))
+        self.assertEqual(bcs.deserialize(cser, typing.Sequence[bytes]), (c, b""))
+
     def test_serialize_tuple(self):
         T = typing.Tuple[st.uint8, st.uint16]
         self.assertEqual(bcs.serialize((0, 1), T), b"\x00\x01\x00")

--- a/serde-generate/runtime/python/serde_binary/__init__.py
+++ b/serde-generate/runtime/python/serde_binary/__init__.py
@@ -47,7 +47,14 @@ class BinarySerializer:
             st.char: self.serialize_char,
             str: self.serialize_str,
             bytes: self.serialize_bytes,
+            typing.Sequence[bytes]: self.serialize_vec_bytes,
         }
+
+    def serialize_vec_bytes(self, value: typing.Sequence[bytes]):
+        self.serialize_len(len(value))
+        for byte_vec in value:
+            self.serialize_bytes(byte_vec)
+
 
     def serialize_bytes(self, value: bytes):
         self.serialize_len(len(value))
@@ -226,6 +233,7 @@ class BinaryDeserializer:
             st.char: self.deserialize_char,
             str: self.deserialize_str,
             bytes: self.deserialize_bytes,
+            typing.Sequence[bytes]: self.deserialize_vec_bytes,
         }
 
     def read(self, length: int) -> bytes:
@@ -233,6 +241,10 @@ class BinaryDeserializer:
         if value is None or len(value) < length:
             raise st.DeserializationError("Input is too short")
         return value
+
+    def deserialize_vec_bytes(self) -> typing.Sequence[bytes]:
+        length = self.deserialize_len()
+        return [self.deserialize_bytes() for _ in range(length)]
 
     def deserialize_bytes(self) -> bytes:
         length = self.deserialize_len()


### PR DESCRIPTION
### Summary
Adds support for `vec<vec<u8>`.

### Why
1. Needed for sdk generation, after [changes to accounts](https://github.com/aptos-labs/aptos-core/pull/3451) was added.
`EncodeResourceAccountCreateResourceAccountAndPublishPackage` fails to compile without this type.
2. [This was added into the main repo](https://github.com/aptos-labs/aptos-core/pull/1815)

Code cherry-picked from a [closed pr in the novi repo](https://github.com/aptos-labs/aptos-core/pull/1815)

## Testing

None, this probably works 🤷 , and generation in aptos-core needs to change to actually generate correctly. 
