### PR TITLE
support ignoring alias fields from trace registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
  "version_check",
 ]
 
@@ -240,18 +240,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -339,9 +339,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -401,13 +401,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -478,6 +478,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -530,8 +541,14 @@ checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 heck = "0.3.2"
 include_dir = "0.6.0"
 maplit = "1.0.2"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.193", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -60,8 +60,7 @@ impl<'a> CodeGenerator<'a> {
         Self {
             config,
             serde_module_path:
-                "github.com/aptos-labs/serde-reflection/serde-generate/runtime/golang"
-                    .to_string(),
+                "github.com/aptos-labs/serde-reflection/serde-generate/runtime/golang".to_string(),
             external_qualified_names,
         }
     }

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -243,7 +243,7 @@ where
             Option(format) => format!("Option<{}>", Self::quote_type(format, known_sizes)),
             Seq(format) => format!("Vec<{}>", Self::quote_type(format, None)),
             Map { key, value } => format!(
-                "Map<{}, {}>",
+                "std::collections::BTreeMap<{}, {}>",
                 Self::quote_type(key, None),
                 Self::quote_type(value, None)
             ),

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [dependencies]
 thiserror = "1.0.25"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.193", features = ["derive"] }
 once_cell = "1.7.2"
 
 [dev-dependencies]

--- a/serde-reflection/tests/serde.rs
+++ b/serde-reflection/tests/serde.rs
@@ -478,21 +478,14 @@ fn test_trace_deserialization_with_alias_types() {
     let mut tracer = Tracer::new(TracerConfig::default());
 
     tracer.trace_type::<Foo>(&samples).unwrap();
-    tracer
-        .ignore_aliases(
-            "Foo",
-            &["c"],
-        )
-        .unwrap();
+    tracer.ignore_aliases("Foo", &["c"]).unwrap();
 
     let registry = tracer.registry().unwrap();
     assert_eq!(
         *registry.get("Foo").unwrap(),
-        ContainerFormat::Struct(vec![
-            Named {
-                name: "b".into(),
-                value: Format::Seq(Box::new(Format::U8))
-            }
-        ])
+        ContainerFormat::Struct(vec![Named {
+            name: "b".into(),
+            value: Format::Seq(Box::new(Format::U8))
+        }])
     );
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/aptos-labs/aptos-core/issues/10424

This PR adds support for ignoring aliases of fields from the trace registry via a new API. In https://github.com/serde-rs/serde/pull/2387, serde allowed both field names and aliases to be considered as field names during deserialization. This breaks the serde-reflection tracer, because it can only trace one field while it expects to trace multiple fields denoted by the field names and aliases. Also, serde doesn't currently denote whether a field is an alias or not in the [Deserializer trait](https://docs.rs/serde/latest/serde/trait.Deserializer.html#tymethod.deserialize_struct).

To work around this issue, this PR adds a new API `ignore_aliases` that can be called to manually ignore the aliases in a struct container from the resource registry.

This change maintains backwards compatibility in terms of generated format spec file.

## Test Plan

Added unit test to reproduce the issue and use `ignore_aliases ` to fix the issue.
