### PR TITLE
serde-generate: depend on forked bcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,8 @@ dependencies = [
 
 [[package]]
 name = "bcs"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
+version = "0.1.4"
+source = "git+https://github.com/aptos-labs/bcs.git?rev=d31fab9d81748e2594be5cd5cdf845786a30562d#d31fab9d81748e2594be5cd5cdf845786a30562d"
 dependencies = [
  "serde",
  "thiserror",
@@ -240,18 +239,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -407,7 +406,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -482,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -526,22 +525,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.72",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -27,7 +27,7 @@ textwrap = "0.13.4"
 
 serde-reflection = { path = "../serde-reflection", version = "0.3.5" }
 bincode = "1.3.3"
-bcs = "0.1.3"
+bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/serde-name/Cargo.toml
+++ b/serde-name/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-thiserror = "1.0.25"
+thiserror = "1.0.60"
 serde = { version = "1.0.126", features = ["derive"] }
 
 [dev-dependencies]

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-thiserror = "1.0.25"
+thiserror = "1.0.60"
 serde = { version = "1.0.193", features = ["derive"] }
 once_cell = "1.7.2"
 


### PR DESCRIPTION
## Summary

To avoid bcs being present in two versions in dependency graphs, change the bcs dependency to the revision of the forked bcs crate that is used in aptos-core.

## Test Plan

Existing tests should pass with the updated dependencies.